### PR TITLE
Create approval-process document - first draft for committee's review

### DIFF
--- a/constititution-level-resources/approval-process.md
+++ b/constititution-level-resources/approval-process.md
@@ -1,0 +1,26 @@
+# Decision-making and Approval Process for Steering Committee
+
+*This document is adapted from [OLS's governance document](https://github.com/open-life-science/ols-governance/blob/main/docs/decision-making-process.md).*
+
+**Agenda for Decision-Making:** The Steering Committee will review and discuss the executive report shared by the executive directors or other members of the executive team during each Steering Committee meeting. Additional agenda points can be proposed by the Steering Committee members and shared through designated channels (Slack and Email) for the Steering Committee at least one week before each meeting, and may be updated until the day before. The Chair and Secretary will communicate if a decision or recommendation regarding any matter needs to be made before, during, or after the meeting.
+
+**Voting/Recommendation Platform:** Voting will take place via GitHub issue, where each Steering Steering Committee member will be invited to comment and indicate their preference using the following options: "Agree", "Disagree", "Abstain", or request further clarification. This will often occur through comments and [using “emoji” reactions on a GitHub issue](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/). Recommendations on any matter discussed with the Steering Committee will also be made via GitHub issues.
+
+**Modalities:** To encourage active participation and input within the Steering Committee, two modes will be available for decision-making and recommendation: 1) **Synchronously:** During Steering Committee meetings, where notes can be live-recorded on the issue, and 2) **Asynchronously:** Through engagement on the GitHub issue.
+Anonymity is not supported in either mode. For anonymous feedback, the Steering Committee can contact the Chair and Secretary via email or Slack, addressing both or a specific member.
+
+**Types of Voting:** Active members can express their position on a GitHub issue by commenting with "Agree," "Disagree," or "Abstain" regarding the presented initiative. Members who "Disagree" or "Abstain" must provide a written justification (in a comment) to help improve the resources, initiative, or other discussion points. This enables the Steering Committee to reach collective decisions or formulate recommendations for the Chair and Secretary to consider.
+
+**Informed Voting:** The Steering Committee will discuss and address each agenda item, providing an opportunity for all perspectives to be heard and expressed. The proposed modalities will allow for consideration of both supporting and opposing arguments before concluding the decision-making and recommendation process within the designated timeframe.
+
+**Steering Committee’s Approval:** Decisions will require approval by at least a two-thirds affirmative vote of active Steering Committee members. It is crucial to understand that the Steering Committee's decision-making process allows them to make recommendations to the community, gather feedback, and setting clear timeline for taking actions that affect _The Turing Way_ activities.
+
+**Tied Votes:** In the event of an indecisive voting outcome from the Steering Committee's voting process, the Steering Committee Chair will be responsible for resolving the issue by either casting a vote between the tied options or assessing additional inputs from the Steering Committee members and community.
+
+**Red Flags:** As a remedy in exceptional situations where active Steering Committee members believe that the issues addressed or submitted to vote do not or may not comply with _The Turing Way_’s goals or values, they can activate this mechanism. To do so, they must contact the chair, or if they feel comfortable, full Steering Committee via Slack or Email within 5 working days. The issue must then be discussed again asynchronously, in a scheduled meeting, or in an extraordinary meeting.
+
+**Involving the Community in Decision-Making:** Decisions and recommendations on matters affecting the entire community should be open for community discussion before final approval. In such cases, a dedicated GitHub issue will be created, describing the matter, sharing relevant resources, and outlining a process for community members to express their concerns, feedback, and recommendations. The voting process and timeline will be explicitly announced via a GitHub issue/discussion, cross-posted to the community Slack channel and newsletter.
+
+**Timeframe:** For each request requiring community voting or recommendations, a timeframe of at least 5 days and at most 8 weeks will be provided after the Steering Committee approves the community engagement plan for that decision.
+
+**Transparency Report:** The Steering Committee will regularly develop and publish a transparency report to publicly record key discussions, organisational decisions, and recommendations made for executive leadership and/or community review. This report will be shared via a public repository and the newsletter. Subsequent reports may include follow-ups on previously reported outcomes, such as how recommendations were integrated into the organisation's work.


### PR DESCRIPTION
This draft is based on OLS's approval process doc: https://github.com/open-life-science/ols-governance/blob/main/docs/decision-making-process.md

The Steering Committee can use this as a starting point and adapt it to support the committee's work