### PR TITLE
Add Collaboration Cafe notes for March 4, 2026

### DIFF
--- a/community-calls/collaboration-cafe/20260304-collaboration-cafe.md
+++ b/community-calls/collaboration-cafe/20260304-collaboration-cafe.md
@@ -1,0 +1,26 @@
+# Collaboration Cafe Notes - 4 March 2026
+
+Chair: Sara Villa
+
+Name + Pronouns + xxxxx + an emoji (if you'd like!: https://emojipedia.org/, see also: https://openmoji.org/)
+(Remember that this is a public document. These notes will be archived on The Turing Way repository, and will include your name and answer. You can use a pseudonym if you'd prefer. Use the 🤫 emoji if you would not like to be included in our public archive. You can always request to remove your information at theturingway@gmail.com)
+
+Esther Plomp / she/her
+Sara Villa / she/her / 🤧
+Kelly Tunley /She/her
+Jim Madge / he/him / 🥱
+Kirstie Whitaker / she/her / @KirstieJane / 
+Emily Wells / she / her
+Cecilia Baldoni / she/her / 
+Batool 
+Malvika / she/her / 🍪 (how early in the day is too early to eat a cookie?)
+
+
+## Breakout rooms: Topic proposals and notes✨ 
+While no sign-ups are required to attend Collaboration Cafe, if you have an idea for a topic you'd like to discuss in a breakout room, please add it below and put your name next to it. 
+If you like one of the topics that are already suggested, please add your name next to that one. For more information about breakout rooms see the description on GitHub https://github.com/alan-turing-institute/the-turing-way/blob/main/project_management/online-collaboration-cafe.md#breakout-rooms).
+
+Accessibility WG
+Review of PRs by Esther on Research  
+data cleaning: https://github.com/the-turing-way/the-turing-way/pull/4544
+Research Data Management: https://github.com/the-turing-way/the-turing-way/pull/4556


### PR DESCRIPTION
Added notes for the Collaboration Cafe held on March 4, 2026, including participant names and proposed breakout room topics.